### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,38 +6,38 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DMD					KEYWORD1
+DMD	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-writePixel			KEYWORD2
-drawString			KEYWORD2
-drawChar			KEYWORD2
-selectFont			KEYWORD2
-charWidth			KEYWORD2
-drawMarquee			KEYWORD2
-stepMarquee			KEYWORD2
-clearScreen			KEYWORD2
-drawLine			KEYWORD2
-drawCircle			KEYWORD2
-drawBox				KEYWORD2
-drawFilledBox		KEYWORD2
-drawTestPattern		KEYWORD2
+writePixel	KEYWORD2
+drawString	KEYWORD2
+drawChar	KEYWORD2
+selectFont	KEYWORD2
+charWidth	KEYWORD2
+drawMarquee	KEYWORD2
+stepMarquee	KEYWORD2
+clearScreen	KEYWORD2
+drawLine	KEYWORD2
+drawCircle	KEYWORD2
+drawBox	KEYWORD2
+drawFilledBox	KEYWORD2
+drawTestPattern	KEYWORD2
 scanDisplayBySPI	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-GRAPHICS_NORMAL		LITERAL1
+GRAPHICS_NORMAL	LITERAL1
 GRAPHICS_INVERSE	LITERAL1
-GRAPHICS_TOGGLE		LITERAL1
-GRAPHICS_OR			LITERAL1
-GRAPHICS_NOR		LITERAL1
+GRAPHICS_TOGGLE	LITERAL1
+GRAPHICS_OR	LITERAL1
+GRAPHICS_NOR	LITERAL1
 
-PATTERN_ALT_0		LITERAL1
-PATTERN_ALT_1		LITERAL1
+PATTERN_ALT_0	LITERAL1
+PATTERN_ALT_1	LITERAL1
 PATTERN_STRIPE_0	LITERAL1
 PATTERN_STRIPE_1	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords